### PR TITLE
Generate lights for all valid (integer) supply_area_distances

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -8,9 +8,20 @@ StartUp = function()
 	ModSettings.PowerPoleWireReachLightedMultiplier = tonumber(settings.startup["power-pole-wire-reach-lighted-percent"].value) / 100
 end
 
+PowerPoleToLightName = {}
+
+LoadConstants = function()
+	for power_pole_name, power_pole in pairs(game.entity_prototypes) do
+		if power_pole.type == "electric-pole" then
+			local supply_area_distance = math.ceil(power_pole.supply_area_distance)
+			PowerPoleToLightName[power_pole_name] = "light-" .. supply_area_distance
+		end
+	end
+end
+
+
 OnPowerPoleBuilt = function(entity)
-	local poleLightName = entity.name .. "-light"
-	if game.entity_prototypes[poleLightName] == nil then return end
+	local poleLightName = PowerPoleToLightName[entity.name]
 	local poleLight = entity.surface.find_entity(poleLightName, entity.position)
 	if poleLight ~= nil then return end
 	entity.surface.create_entity{
@@ -21,8 +32,7 @@ OnPowerPoleBuilt = function(entity)
 end
 
 OnPowerPoleRemoved = function(entity)
-	local poleLightName = entity.name .. "-light"
-	if game.entity_prototypes[poleLightName] == nil then return end
+	local poleLightName = PowerPoleToLightName[entity.name]
 	local poleLight = entity.surface.find_entity(poleLightName, entity.position)
 	if poleLight == nil then return end
 	poleLight.destroy()

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,10 +1,10 @@
 GeneratePowerPoleLights = function()
 	local poleLights = {}
 	local powerPoleWireReachLightedMultiplier = tonumber(settings.startup["power-pole-wire-reach-lighted-percent"].value) / 100
-	for _, pole in pairs(data.raw["electric-pole"]) do
-		local poleLightRange = powerPoleWireReachLightedMultiplier * pole.supply_area_distance * 5
+	for supply_area_distance=1,64 do
+		local poleLightRange = powerPoleWireReachLightedMultiplier * supply_area_distance * 5
 		local poleLight = table.deepcopy(data.raw["lamp"]["small-lamp"])
-		poleLight.name = pole.name .. "-light"
+		poleLight.name = "light-" .. supply_area_distance
 		poleLight.collision_mask = {"resource-layer"}
 		poleLight.flags = {"not-blueprintable", "not-deconstructable", "placeable-off-grid", "not-on-map"}
 		poleLight.selectable_in_game = false


### PR DESCRIPTION
Generate lights for all valid (integer) supply_area_distances, because there's nothing stopping a mod from adding new power poles in data-final-fixes.

Change control.lua to build a lookup table of electric_pole.name pole to light.name, and use that to pick which light to place for a given power pole.